### PR TITLE
Eliminate duplicate var call for temp, corrected syntax error

### DIFF
--- a/weather.rb
+++ b/weather.rb
@@ -1,9 +1,8 @@
 require "yahoo_weatherman"
 
 def get_weather(zipcode)
-    temp = zipcode.to_i
     client = Weatherman::Client.new
-    temp = client.lookup_by_location(zipcode).condition[temp]
+    temp = client.lookup_by_location(zipcode).condition['temp']
     return temp.to_i
 end
 


### PR DESCRIPTION
Temp var was being called twice, and was overwriting the zipcode input.  Also fixed a syntax error when passing temp as an argument to .condition.
